### PR TITLE
Rename mbed-google-client to mbed-client-for-google-iot-cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ It has been tested on K64F with Ethernet and DISCO_L475VG_IOT01A with WiFi, but 
 1. Clone this repository on your system, and change the current directory to where the project was cloned:
 
     ```
-    $ git clone git@github.com:armmbed/mbed-os-example-google-cloud && cd mbed-os-example-google-cloud
+    $ git clone git@github.com:armmbed/mbed-os-example-for-google-iot-cloud && cd mbed-os-example-for-google-iot-cloud
     $ mbed deploy
     ```
 
     Alternatively, you can download the example project with Arm Mbed CLI using the `import` subcommand:
 
     ```
-    $ mbed import mbed-os-example-google-cloud && cd mbed-os-example-google-cloud
+    $ mbed import mbed-os-example-for-google-iot-cloud && cd mbed-os-example-for-google-iot-cloud
     ```
 
 ## Configuring the Google Cloud IoT Core

--- a/mbed-client-for-google-iot-cloud.lib
+++ b/mbed-client-for-google-iot-cloud.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed//mbed-client-for-google-iot-cloud#104c4af4e54728a3881f44e36db939f7c9488f03

--- a/mbed-google-client.lib
+++ b/mbed-google-client.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-google-client.git#f4f8512316dca9c1409f3d56060955cf535721c1


### PR DESCRIPTION
- Renamed mbed-google-client.lib to mbed-client-for-google-iot-cloud.lib as suggested.
- Updated mbed-client-for-google-iot-cloud.lib to refer mbed-client-for-google-iot-cloud.