### PR TITLE
Google cloud example test automation

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -24,8 +24,7 @@
     },
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": true,
-            "platform.stdio-baud-rate": 115200
+            "platform.stdio-convert-newlines": true
         },
         "DISCO_L475VG_IOT01A": {
             "target.components_add": ["wifi_ism43362"],

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Testing examples
+
+Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log.
+
+To run the test, use following command after you build the example:
+```
+mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\mbed-os-example-for-google-iot-cloud.bin --compare-log tests\google-iot-cloud.log
+```
+
+
+More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).

--- a/tests/google-iot-cloud.log
+++ b/tests/google-iot-cloud.log
@@ -1,0 +1,23 @@
+connected to mqtt.2030.ltsapis.goog\:8883
+publishing msg "10 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "9 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "8 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "7 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "6 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "5 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "4 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "3 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "2 messages left to send, or until we receive a reply"
+Message sent successfully
+publishing msg "1 messages left to send, or until we receive a reply"
+Message sent successfully
+Message body: Hello from Google cloud IOT Core
+Done


### PR DESCRIPTION
- Added the readme procedure for running this test
- Added the .log file which is used by `mbedhtrun` for comparing with console logs after execution
- Removed the baudrate `115200` configs as `mbedhtrun` supports only `9600` baudrate