### PR TITLE
CI test update

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -286,8 +286,6 @@ int main(int argc, char *argv[])
     iotc_shutdown();
 
     printf("Done\n");
-    while (true) {
-        sleep();
-    }
+
     return 0;
 }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -24,7 +24,8 @@
     },
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": true
+            "platform.stdio-convert-newlines": true,
+            "platform.stdio-baud-rate": 115200
         },
         "DISCO_L475VG_IOT01A": {
             "target.components_add": ["wifi_ism43362"],

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/
 
 To run the test, use following command after you build the example:
 ```
-mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\mbed-os-example-for-google-iot-cloud.bin --compare-log tests\google-iot-cloud.log --baud-rate=115200 --sync=0
+mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\mbed-os-example-for-google-iot-cloud.bin --compare-log tests\google-iot-cloud.log --baud-rate=115200 --sync=0 -P 120
 ```
 
 More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,8 +4,7 @@ Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/
 
 To run the test, use following command after you build the example:
 ```
-mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\mbed-os-example-for-google-iot-cloud.bin --compare-log tests\google-iot-cloud.log
+mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\mbed-os-example-for-google-iot-cloud.bin --compare-log tests\google-iot-cloud.log --baud-rate=115200 --sync=0
 ```
-
 
 More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).


### PR DESCRIPTION
This PR
* reverts the baud rate to 115200, as indicated by [examples.json](https://github.com/ARMmbed/mbed-os/blob/ad40b1b2672d59b058f7c104fdc612d0dddf3ac3/tools/test/examples/examples.json#L512) in mbed-os and supported by the mbedhtrun. See discussions in https://github.com/ARMmbed/mbed-os-example-for-google-iot-cloud/pull/13#discussion_r501806079.
* updates the instructions to add missing `--sync=0` (examples are not triggered by preambles as Greentea tests are) and set baud rate

@ARMmbed/mbed-os-core @evedon 