### PR TITLE
CMake: Add CMake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,105 @@
+# Copyright (c) 2020 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: sh
+os: linux
+dist: xenial
+
+env:
+  global:
+    - PROFILE=develop
+
+cache:
+  pip: true
+  ccache: true
+  # It looks like ccache for arm-none-eabi is not yet supported by Travis.
+  # Therefore manually adding ccache directory to cache
+  directories:
+    - ${HOME}/.ccache
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
+    packages:
+      - cmake
+      - ninja-build
+
+matrix:
+  include:
+
+    - &cmake-build-test
+      stage: "CMake"
+      name: "CMake Google IoT Cloud example - develop (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=develop  CACHE_NAME=develop-K64F
+      language: python
+      python: 3.8
+      install:
+        # Setup ccache
+        - ccache -o compiler_check=content
+        - ccache -M 1G
+        - pushd /usr/lib/ccache
+        - sudo ln -s ../../bin/ccache arm-none-eabi-gcc
+        - sudo ln -s ../../bin/ccache arm-none-eabi-g++
+        - export PATH="/usr/lib/ccache:$PATH"
+        - popd
+        # Install arm-none-eabi-gcc
+        - pushd /home/travis/build && mkdir arm-gcc && cd arm-gcc
+        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&la=en&hash=D7C9D18FCA2DD9F894FD9F3C3DC9228498FA281A" --output gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - tar xf gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
+        - popd
+        - arm-none-eabi-gcc --version
+        # Hide Travis-preinstalled CMake
+        # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+        # can't replace it with an apt-supplied version very easily. Additionally, we
+        # can't permit the Travis-preinstalled copy to survive, as the Travis default
+        # path lists the Travis CMake install location ahead of any place where apt
+        # would install CMake to. Instead of apt removing or upgrading to a new CMake
+        # version, we must instead delete the Travis copy of CMake.
+        - sudo rm -rf /usr/local/cmake*
+        - pip install --upgrade mbed-tools
+        - pip install prettytable==0.7.2
+        - pip install future==0.16.0
+        - pip install "Jinja2>=2.10.1,<2.11"
+        - pip install "intelhex>=1.3,<=2.2.1"
+      script:
+        - mbedtools checkout
+        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - ccache -s
+
+    - <<: *cmake-build-test
+      name: "CMake Google IoT Cloud example - release (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=release CACHE_NAME=release-K64F
+
+    - <<: *cmake-build-test
+      name: "CMake Google IoT Cloud example - debug (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=debug CACHE_NAME=debug-K64F
+
+    - <<: *cmake-build-test
+      name: "CMake Google IoT Cloud example - develop (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=develop CACHE_NAME=develop-DISCO_L475VG_IOT01A
+
+    - <<: *cmake-build-test
+      name: "CMake Google IoT Cloud example - release (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=release CACHE_NAME=release-DISCO_L475VG_IOT01A
+
+    - <<: *cmake-build-test
+      name: "CMake Google IoT Cloud example - debug (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=debug CACHE_NAME=debug-DISCO_L475VG_IOT01A

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,59 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET mbed-os-example-for-google-iot-cloud)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(${MBED_PATH})
+
+add_subdirectory(mbed-client-for-google-iot-cloud)
+add_subdirectory(ntp-client)
+
+if("wifi_ism43362" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(wifi-ism43362)
+endif()
+
+add_executable(${APP_TARGET})
+
+mbed_configure_app_target(${APP_TARGET})
+
+mbed_set_mbed_target_linker_script(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_include_directories(${APP_TARGET}
+    PRIVATE
+        .
+)
+
+target_sources(${APP_TARGET}
+    PRIVATE
+        main.cpp
+)
+
+if("wifi_ism43362" IN_LIST MBED_TARGET_LABELS)
+    target_link_libraries(${APP_TARGET}
+        PRIVATE
+            wifi-ism43362
+    )
+endif()
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        mbed-os
+        ntp-client
+        mbed-mbedtls
+        mbed-client-for-google-iot-cloud
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/mbed-client-for-google-iot-cloud.lib
+++ b/mbed-client-for-google-iot-cloud.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-client-for-google-iot-cloud#a79f533d2546b5d7a493bc5cc3edffb961f11887
+https://github.com/ARMmbed/mbed-client-for-google-iot-cloud#cbf19de89b83f870992811d9654b6d38ad7fa94e

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783
+https://github.com/ARMmbed/mbed-os/

--- a/ntp-client.lib
+++ b/ntp-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/ntp-client.git#a4ccf62992b9adc5086a9afea08fa4deb2e2fbd7
+https://github.com/ARMmbed/ntp-client.git#e919cfb14e2029efafc0d1288a0223cbd09811f0

--- a/wifi-ism43362.lib
+++ b/wifi-ism43362.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-ism43362/#9e1851a7fe5e2ffb07533aacc7114df2e73f7784
+https://github.com/ARMmbed/wifi-ism43362/#ee466577559ec733e5d3c88c55517a40cb03f537


### PR DESCRIPTION
- Added CMakeLists.txt file to Google IoT Cloud example so that it can build via CMake
- Added .travis.yml config to pick this example for Travis CI build
- Update mbed-os.lib to latest master to pick CMake changes



@0xc0170 @hugueskamba @LDong-Arm 