### PR TITLE
Fix mbed-tool support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,9 @@ matrix:
         - pip install "Jinja2>=2.10.1,<2.11"
         - pip install "intelhex>=1.3,<=2.2.1"
       script:
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *cmake-build-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@ endif()
 
 add_executable(${APP_TARGET})
 
-mbed_configure_app_target(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,12 @@
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
-set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-for-google-iot-cloud)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
 add_subdirectory(${MBED_PATH})
-
 add_subdirectory(mbed-client-for-google-iot-cloud)
 add_subdirectory(ntp-client)
 
@@ -21,8 +20,6 @@ endif()
 add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
-
-mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,18 @@ You can build the project with all supported [Mbed OS build tools](https://os.mb
 
 It has been tested on K64F with Ethernet and DISCO_L475VG_IOT01A with WiFi, but any Mbed OS 6 targets with Internet access should work.
 
-## Downloading this project
-1. [Install Mbed CLI](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+## Mbed OS build tools
 
-1. Clone this repository on your system, and change the current directory to where the project was cloned:
+### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner. If you are working with Mbed OS version prior to 6.5 then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-example-for-google-iot-cloud`
+1. Change the current directory to where the project was imported.
 
-    ```
-    $ git clone https://github.com/ARMmbed/mbed-os-example-for-google-iot-cloud.git && cd mbed-os-example-for-google-iot-cloud
-    $ mbed deploy
-    ```
-
-    Alternatively, you can download the example project with Arm Mbed CLI using the `import` subcommand:
-
-    ```
-    $ mbed import mbed-os-example-for-google-iot-cloud && cd mbed-os-example-for-google-iot-cloud
-    ```
+### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+1. From the command-line, import the example: `mbed import mbed-os-example-for-google-iot-cloud`
+1. Change the current directory to where the project was imported.
 
 ## Configuring the Google Cloud IoT Core
 
@@ -69,9 +66,19 @@ It has been tested on K64F with Ethernet and DISCO_L475VG_IOT01A with WiFi, but 
 1. For Ethernet (e.g on K64F), connect a cable to the port.
 1. Connect your development board to your PC with a USB cable.
 1. Compile, flash and run the example
+
+    * Mbed CLI 2
+
+    ```bash
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN> --flash  --sterm
     ```
-    mbed compile -m <TARGET> -t <TOOLCHAIN> -f --sterm --baud 115200
+
+    * Mbed CLI 1
+
+    ```bash
+    $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash  --sterm
     ```
+
 For example, `<TARGET>` can be `DISCO_L475VG_IOT01A` and `<TOOLCHAIN>` can be `GCC_ARM` if you want to use this combination.
 
 ## Expected output

--- a/wifi-ism43362.lib
+++ b/wifi-ism43362.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-ism43362/#ee466577559ec733e5d3c88c55517a40cb03f537
+https://github.com/ARMmbed/wifi-ism43362/#3813a4bb8623cc9b0525978748581f60d47142fa


### PR DESCRIPTION
Fixes #25

`.travis.yml`:
* Update mbed-tools commands

`drivers/COMPONENT_wifi_ism43362.lib`:
* Use the latest version to bring in compilation fixes

`CMakeLists.txt`:
* Update the configuration path generated by mbed-tools
* Remove mbed_set_mbed_target_linker_script() call which is no longer
  present in Mbed OS.